### PR TITLE
✏️chore: k8s mongodb 설정 application-prod에 추가

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,3 +23,5 @@ spring:
     elasticsearch:
       rest:
         uris: http://localhost:9200
+    mongodb:
+      uri: mongodb://localhost:27017/news_database  # MongoDB URI

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,3 +28,6 @@ spring:
         enabled: true    # Readiness 상태를 활성화
   elasticsearch:
     uris: http://elasticsearch:9200
+  data:
+    mongodb:
+      uri: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongodb.startupservice.svc.cluster.local:27017/news_database?authSource=admin

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,5 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     # MongoDB 설정 추가
-  data:
-    mongodb:
-      uri: mongodb://localhost:27017/news_database  # MongoDB URI
 server:
   port: 8080


### PR DESCRIPTION
### ✨ 작업한 내용
k8s startupservice 네임스페이스에 mongodb를 올리고, statefulset, headless service 세팅 스프링 연동을 위해서 
application-prod에 추가

변경 전
```yaml
mongodb:
   uri: mongodb://localhost:27017/news_database  # MongoDB URI
```
변경 후
```yaml
mongodb:
   uri: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongodb.startupservice.svc.cluster.local:27017/news_database?authSource=admin

```