### PR TITLE
✨ feat: campaignId set API 추가

### DIFF
--- a/src/main/java/com/picktartup/startup/controller/StartupController.java
+++ b/src/main/java/com/picktartup/startup/controller/StartupController.java
@@ -4,6 +4,7 @@ import com.picktartup.startup.common.dto.ApiResponse;
 import com.picktartup.startup.dto.AnnualMetricsResponse;
 import com.picktartup.startup.dto.MetricsChartResponse;
 import com.picktartup.startup.dto.MonthlyMetricsResponse;
+import com.picktartup.startup.dto.SetCampaignIdRequest;
 import com.picktartup.startup.dto.StartupElasticsearch;
 import com.picktartup.startup.dto.StartupServiceRequest;
 import com.picktartup.startup.service.StartupService;
@@ -111,5 +112,14 @@ public class StartupController {
     ) {
         return ResponseEntity.ok(startupService.getMetricsForChart(startupId, period));
     }
-    
+
+
+    // PATCH 요청으로 campaignId 업데이트
+    @PatchMapping("/{startupId}/campaign")
+    public ResponseEntity<String> updateCampaignId(
+            @PathVariable Long startupId,
+            @RequestBody SetCampaignIdRequest request) {
+        startupService.updateCampaignId(new SetCampaignIdRequest(startupId, request.getCampaignId()));
+        return ResponseEntity.ok("Campaign ID updated successfully");
+    }
 }

--- a/src/main/java/com/picktartup/startup/dto/SetCampaignIdRequest.java
+++ b/src/main/java/com/picktartup/startup/dto/SetCampaignIdRequest.java
@@ -1,0 +1,13 @@
+package com.picktartup.startup.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SetCampaignIdRequest {
+    private Long startupId;
+    private Integer campaignId;
+}

--- a/src/main/java/com/picktartup/startup/service/StartupService.java
+++ b/src/main/java/com/picktartup/startup/service/StartupService.java
@@ -3,6 +3,7 @@ package com.picktartup.startup.service;
 import com.picktartup.startup.dto.AnnualMetricsResponse;
 import com.picktartup.startup.dto.MetricsChartResponse;
 import com.picktartup.startup.dto.MonthlyMetricsResponse;
+import com.picktartup.startup.dto.SetCampaignIdRequest;
 import com.picktartup.startup.dto.StartupElasticsearch;
 import com.picktartup.startup.dto.StartupServiceRequest;
 
@@ -21,4 +22,5 @@ public interface StartupService {
     List<MonthlyMetricsResponse> getMonthlyMetrics(Long startupId);
     List<MetricsChartResponse> getMetricsForChart(Long startupId, String period);
 
+    void updateCampaignId(SetCampaignIdRequest request);
 }

--- a/src/main/java/com/picktartup/startup/service/StartupServiceImpl.java
+++ b/src/main/java/com/picktartup/startup/service/StartupServiceImpl.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -278,6 +279,20 @@ public class StartupServiceImpl implements StartupService {
                     .collect(Collectors.toList());
         }
     }
+
+
+    @Transactional
+    @Override
+    public void updateCampaignId(SetCampaignIdRequest request) {
+        Startup startup = startupRepository.findById(request.getStartupId())
+                .orElseThrow(() -> new RuntimeException("Startup not found with ID: " + request.getStartupId()));
+
+        startup.setCampaignId(request.getCampaignId());
+        startupRepository.save(startup);
+
+        log.info("Updated campaignId for startupId {}: {}", request.getStartupId(), request.getCampaignId());
+    }
+
 
 
 }


### PR DESCRIPTION
### 👀 관련 이슈
- #33 

### ✨ 작업한 내용
- **Campaign 기능 구현**
  - `PATCH /api/startups/{startupId}/campaign`: `campaignId`를 JSON Body로 받아 `startupId`에 연결.



### 🌀 PR Point
- 요청 JSON 형식 및 매핑 방식이 적절한지 검토 부탁드립니다.



### 🍰 참고사항
- `campaignId` 필드는 숫자 형식(Integer)으로 JSON Body에서 매핑됩니다.
- Postman 테스트 케이스:
  - 요청 경로: `PATCH /api/startups/1/campaign`
  - 요청 Body:
    ```json
    {
        "campaignId": 11
    }
    ```


### 📷 스크린샷 또는 GIF
| **기능**              | **스크린샷**               |
|-----------------------|---------------------------|
| Postman 요청 | ![image](https://github.com/user-attachments/assets/c587ce44-932c-4bb7-8fb1-9501a916cd49)   |
| Postman 응답 |![image](https://github.com/user-attachments/assets/86d1d0cd-d60d-4d79-b2ac-f85ec2b76c29) |

