### PR TITLE
✨ feat: AOP 추가 (API 응답 시간, http_method 등등

### DIFF
--- a/src/main/java/com/picktartup/startup/aop/StartupLoggingAspect.java
+++ b/src/main/java/com/picktartup/startup/aop/StartupLoggingAspect.java
@@ -1,101 +1,206 @@
 package com.picktartup.startup.aop;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.picktartup.startup.dto.StartupElasticsearch;
 import com.picktartup.startup.dto.StartupServiceRequest;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.hibernate.stat.internal.StatisticsImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.hibernate.Session;
 
 @Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class StartupLoggingAspect {
+    private static final Logger logger = LoggerFactory.getLogger("API_METRICS");
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final EntityManager entityManager;
 
-    private void logBusinessAction(String action, Map<String, Object> additionalFields) {
+    // API 성능 및 쿼리 모니터링
+    @Around("execution(* com.picktartup.startup.controller.*.*(..))")
+    public Object logAPIMetrics(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
         Map<String, Object> logData = new HashMap<>();
-        logData.put("log_type", "business");
-        logData.put("action", action);
-        logData.put("timestamp", LocalDateTime.now().toString());
-        logData.putAll(additionalFields);
 
-        log.info("{}", logData);
+        // 기본 메타데이터
+        logData.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        logData.put("request_id", UUID.randomUUID().toString());
+
+        // API 정보
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+                .currentRequestAttributes()).getRequest();
+        logData.put("http_method", request.getMethod());
+        logData.put("uri", request.getRequestURI());
+        logData.put("client_ip", request.getRemoteAddr());
+
+        // API 엔드포인트 정보
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        logData.put("api_name", signature.getDeclaringType().getSimpleName() + "." + signature.getName());
+        logData.put("api_path", request.getRequestURI().replaceAll("/\\d+", "/{id}"));
+
+        // 쿼리 성능 측정
+        //int initialQueryCount = getQueryCount();
+
+        try {
+            Object result = joinPoint.proceed();
+
+            // 응답 메트릭
+            long executionTime = System.currentTimeMillis() - startTime;
+            //int finalQueryCount = getQueryCount() - initialQueryCount;
+
+            logData.put("response_time_ms", executionTime);
+            logData.put("status", getStatusCode(result));
+            logData.put("success", true);
+
+            // 쿼리 성능 메트릭
+//            Map<String, Object> queryMetrics = new HashMap<>();
+//            queryMetrics.put("query_count", finalQueryCount);
+//            queryMetrics.put("avg_query_time_ms", finalQueryCount > 0 ? executionTime / finalQueryCount : 0);
+//
+//            if (finalQueryCount > 10) {
+//                queryMetrics.put("warning", "possible_n_plus_one");
+//            }
+//            logData.put("query_performance", queryMetrics);
+
+            // 느린 API 경고
+            if (executionTime > 1000) {
+                logData.put("warning", "slow_api");
+            }
+
+            logger.info(objectMapper.writeValueAsString(logData));
+            return result;
+
+        } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+            logData.put("response_time_ms", executionTime);
+            logData.put("status", getErrorStatusCode(e));
+            logData.put("success", false);
+            logData.put("error_type", e.getClass().getSimpleName());
+            logData.put("error_message", e.getMessage());
+
+            logger.error(objectMapper.writeValueAsString(logData));
+            throw e;
+        }
     }
 
-    /**
-     * 스타트업 조회 로깅
-     */
-    @Around("execution(* com.picktartup.startup.service.StartupServiceImpl.getStartupDetailsFromElasticsearch(..)) || " +
-            "execution(* com.picktartup.startup.service.StartupServiceImpl.getStartupDetailsFromPostgresql(..))")
+    // 비즈니스 로직 모니터링 - 스타트업 조회
+    @Around("execution(* com.picktartup.startup.service.StartupServiceImpl.getStartupDetailsFrom*(..))")
     public Object logStartupView(ProceedingJoinPoint joinPoint) throws Throwable {
         Object[] args = joinPoint.getArgs();
         Long startupId = (Long) args[0];
-        LocalDateTime viewTime = LocalDateTime.now();
+
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        logData.put("request_id", UUID.randomUUID().toString());
+        logData.put("startup_id", startupId);
 
         try {
             Object result = joinPoint.proceed();
 
             if (result instanceof StartupServiceRequest) {
                 StartupServiceRequest startup = (StartupServiceRequest) result;
-                logBusinessAction("view_startup", Map.of(
-                        "startupId", startup.getStartupId(),
-                        "name", startup.getName(),
-                        "category", startup.getCategory(),
-                        "timestamp", viewTime,
-                        "hour", viewTime.getHour(),
-                        "dayOfWeek", viewTime.getDayOfWeek().toString()
-                ));
+                logData.put("startup_name", startup.getName());
+                logData.put("category", startup.getCategory());
+                logData.put("status", "success");
+                logData.put("time_of_day", LocalDateTime.now().getHour());
+                logData.put("day_of_week", LocalDateTime.now().getDayOfWeek().toString());
             }
 
+            logger.info(objectMapper.writeValueAsString(logData));
             return result;
+
         } catch (Exception e) {
-            logBusinessAction("view_startup_failed", Map.of(
-                    "startupId", startupId,
-                    "error_message", e.getMessage()
-            ));
+            logData.put("status", "failed");
+            logData.put("error_type", e.getClass().getSimpleName());
+            logData.put("error_message", e.getMessage());
+            logger.error(objectMapper.writeValueAsString(logData));
             throw e;
         }
     }
 
-    /**
-     * 스타트업 검색 로깅
-     */
+    // 비즈니스 로직 모니터링 - 검색
     @Around("execution(* com.picktartup.startup.service.StartupServiceImpl.searchStartupsByKeyword(..))")
     public Object logStartupSearch(ProceedingJoinPoint joinPoint) throws Throwable {
         Object[] args = joinPoint.getArgs();
         String keyword = (String) args[0];
-        LocalDateTime searchTime = LocalDateTime.now();
+
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        logData.put("request_id", UUID.randomUUID().toString());
+        logData.put("search_keyword", keyword);
 
         try {
             Object result = joinPoint.proceed();
 
             if (result instanceof List) {
                 List<StartupElasticsearch> startups = (List<StartupElasticsearch>) result;
+                logData.put("results_count", startups.size());
+                logData.put("status", "success");
+                logData.put("time_of_day", LocalDateTime.now().getHour());
+                logData.put("day_of_week", LocalDateTime.now().getDayOfWeek().toString());
 
-                startups.forEach(startup -> logBusinessAction("search_startup", Map.of(
-                        "keyword", keyword,
-                        "startupId", startup.getStartupId(),
-                        "name", startup.getName(),
-                        "category", startup.getCategory(),
-                        "timestamp", searchTime,
-                        "hour", searchTime.getHour(),
-                        "dayOfWeek", searchTime.getDayOfWeek().toString()
-                )));
+                Map<String, Long> categoryDistribution = startups.stream()
+                        .collect(Collectors.groupingBy(
+                                StartupElasticsearch::getCategory,
+                                Collectors.counting()
+                        ));
+                logData.put("category_distribution", categoryDistribution);
             }
 
+            logger.info(objectMapper.writeValueAsString(logData));
             return result;
+
         } catch (Exception e) {
-            logBusinessAction("search_startup_failed", Map.of(
-                    "keyword", keyword,
-                    "error_message", e.getMessage()
-            ));
+            logData.put("status", "failed");
+            logData.put("error_type", e.getClass().getSimpleName());
+            logData.put("error_message", e.getMessage());
+            logger.error(objectMapper.writeValueAsString(logData));
             throw e;
         }
     }
+
+//    private int getQueryCount() {
+//        return (int) ((StatisticsImpl) entityManager.unwrap(Session.class)
+//                .getSessionFactory()
+//                .getStatistics())
+//                .getQueryExecutionCount();
+//    }
+
+    private int getStatusCode(Object result) {
+        if (result instanceof ResponseEntity) {
+            return ((ResponseEntity<?>) result).getStatusCodeValue();
+        }
+        return 200;
+    }
+
+    private int getErrorStatusCode(Exception e) {
+        if (e instanceof HttpClientErrorException) {
+            return ((HttpClientErrorException) e).getRawStatusCode();
+        }
+        return 500;
+    }
 }
+

--- a/src/main/java/com/picktartup/startup/repository/mongoDB/ArticleRepository.java
+++ b/src/main/java/com/picktartup/startup/repository/mongoDB/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.picktartup.startup.repository.mongoDB;
 
 import com.picktartup.startup.entity.Article;
 import org.springframework.data.mongodb.repository.MongoRepository;
+
 import java.util.List;
 import java.util.Optional;
 


### PR DESCRIPTION
### 👀 관련 이슈
- #35 

### ✨ 작업한 내용
- `StartupController/getStartupDetails` API 호출 로그를 기록하도록 AOP 로직 개선
  - API 메서드 이름, 요청 URI, 응답 시간, HTTP 상태 코드 등의 메타데이터를 포함.
  - JSON 형태로 구조화된 로깅 데이터 제공.
- 응답 시간(`response_time_ms`)과 요청 ID(`request_id`) 기록 추가.
- 향후 N+1 문제 모니터링을 위한 쿼리 카운트 로직 설계 준비.

### 🌀 PR Point
- AOP를 통해 로깅된 데이터가 정확히 반영되는지 확인이 필요.
- 로깅 데이터의 구조와 내용이 직관적으로 해석 가능한지 점검.

### 🍰 참고사항
- 예시 로깅 데이터:
  ```json
  {
    "http_method": "GET",
    "api_name": "StartupController.getStartupDetails",
    "success": true,
    "client_ip": "0:0:0:0:0:0:0:1",
    "response_time_ms": 10,
    "request_id": "a6328a61-c0d9-471a-99c6-e64ec5ff9398",
    "uri": "/api/v1/startups/2",
    "api_path": "/api/v1/startups/{id}",
    "timestamp": "2024-12-04T18:40:59.2026806",
    "status": 200
  }
- N+1 문제에 대한 로깅 데이터는 추후 기능 추가 후 검토 예정.

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|추가된 부분|![image](https://github.com/user-attachments/assets/213cdd46-e31c-4ab4-8e37-d9b901fbd035)|
